### PR TITLE
Fixed broken search of series names

### DIFF
--- a/SdarotAPI/GlobalUsings.cs
+++ b/SdarotAPI/GlobalUsings.cs
@@ -8,3 +8,6 @@ global using System.Net.Http.Json;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;
 global using System.Web;
+global using System.Net;
+global using System.Net.Http.Headers;
+global using System.Text.Json;

--- a/SdarotAPI/Models/SeriesInformation.cs
+++ b/SdarotAPI/Models/SeriesInformation.cs
@@ -1,16 +1,37 @@
+using System.ComponentModel;
+
 namespace SdarotAPI.Models;
 
 public partial class SeriesInformation
 {
+    [JsonPropertyName("heb")]
     public string SeriesNameHe { get; set; }
+    [JsonPropertyName("eng")]
     public string SeriesNameEn { get; set; }
-    public int SeriesCode { get; set; }
+    [JsonPropertyName("id")]
+    public string SeriesId { get; set; }
+
+    public int SeriesCode
+    {
+        get
+        {
+            return int.Parse(SeriesId);
+        }
+        set
+        {
+            SeriesId = value.ToString();
+        }
+    }
 
     [JsonIgnore]
     public string ImageUrl => $"{Constants.SdarotUrls.ImageUrl}{SeriesCode}.jpg";
 
     [JsonIgnore]
     public string SeriesUrl => $"{Constants.SdarotUrls.WatchUrl}{SeriesCode}";
+
+    public SeriesInformation()
+    {
+    }
 
     public SeriesInformation(string seriesNameHe, string seriesNameEn, string imageUrl)
     {

--- a/SdarotAPI/Models/SeriesInformation.cs
+++ b/SdarotAPI/Models/SeriesInformation.cs
@@ -2,14 +2,14 @@ namespace SdarotAPI.Models;
 
 public partial class SeriesInformation
 {
-    [JsonPropertyName("heb")] public string SeriesNameHe { get; set; } = null;
-    [JsonPropertyName("eng")] public string SeriesNameEn { get; set; } = null;
+    [JsonPropertyName("heb")] public string SeriesNameHe { get; set; } = String.Empty;
+    [JsonPropertyName("eng")] public string SeriesNameEn { get; set; } = String.Empty;
     [JsonPropertyName("id")]
     public string SeriesId
     {
         get
         {
-            return SeriesId.ToString();
+            return SeriesCode.ToString();
         }
         set
         {

--- a/SdarotAPI/Models/SeriesInformation.cs
+++ b/SdarotAPI/Models/SeriesInformation.cs
@@ -1,27 +1,23 @@
-using System.ComponentModel;
-
 namespace SdarotAPI.Models;
 
 public partial class SeriesInformation
 {
-    [JsonPropertyName("heb")]
-    public string SeriesNameHe { get; set; }
-    [JsonPropertyName("eng")]
-    public string SeriesNameEn { get; set; }
+    [JsonPropertyName("heb")] public string SeriesNameHe { get; set; } = null;
+    [JsonPropertyName("eng")] public string SeriesNameEn { get; set; } = null;
     [JsonPropertyName("id")]
-    public string SeriesId { get; set; }
-
-    public int SeriesCode
+    public string SeriesId
     {
         get
         {
-            return int.Parse(SeriesId);
+            return SeriesId.ToString();
         }
         set
         {
-            SeriesId = value.ToString();
+            SeriesCode = int.Parse(value);
         }
     }
+
+    public int SeriesCode { get; set; }
 
     [JsonIgnore]
     public string ImageUrl => $"{Constants.SdarotUrls.ImageUrl}{SeriesCode}.jpg";

--- a/SdarotAPI/Resources/Constants.cs
+++ b/SdarotAPI/Resources/Constants.cs
@@ -1,6 +1,4 @@
-﻿using static System.Net.WebRequestMethods;
-
-namespace SdarotAPI.Resources;
+﻿namespace SdarotAPI.Resources;
 
 internal static class Constants
 {

--- a/SdarotAPI/Resources/Constants.cs
+++ b/SdarotAPI/Resources/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace SdarotAPI.Resources;
+﻿using static System.Net.WebRequestMethods;
+
+namespace SdarotAPI.Resources;
 
 internal static class Constants
 {
@@ -14,6 +16,7 @@ internal static class Constants
         public static string ImageUrl => $"https://static.{BaseDomain}/series/";
         public static string TestUrl => $"{WatchUrl}1";
         public static string AjaxWatchUrl => $"{HomeUrl}ajax/watch";
+        public static string AllShowsUrl => $"{HomeUrl}ajax/index?srl=1";
     }
 
     public static class XPathSelectors

--- a/SdarotAPI/SdarotDriver.cs
+++ b/SdarotAPI/SdarotDriver.cs
@@ -72,7 +72,7 @@ public class SdarotDriver
 
         var relevantShows = shows?.Where(x =>
             x.SeriesNameHe.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase) ||
-            x.SeriesNameEn.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase)).ToList() ?? Enumerable.Empty<SeriesInformation>();
+            x.SeriesNameEn.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase)) ?? Enumerable.Empty<SeriesInformation>();
 
         // In case there are more than one result
         return relevantShows;

--- a/SdarotAPI/SdarotDriver.cs
+++ b/SdarotAPI/SdarotDriver.cs
@@ -1,8 +1,4 @@
-﻿using System.Net;
-using System.Net.Http.Headers;
-using System.Text.Json;
-
-namespace SdarotAPI;
+﻿namespace SdarotAPI;
 
 public class SdarotDriver
 {
@@ -76,25 +72,7 @@ public class SdarotDriver
 
         var relevantShows = shows?.Where(x =>
             x.SeriesNameHe.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase) ||
-            x.SeriesNameEn.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase)).ToList();
-
-        // If none, turn to empty array.
-        relevantShows ??= new List<SeriesInformation>();
-
-        // In case there is only one result
-        if (relevantShows.Count() == 1)
-        {
-            var currShow = relevantShows.First();
-            var seriesName = $"{currShow.SeriesNameEn} / {currShow.SeriesNameHe}";
-
-            return new SeriesInformation(HttpUtility.HtmlDecode(seriesName), currShow.ImageUrl).Yield();
-        }
-
-        // In case there are no results
-        if (!relevantShows.Any())
-        {
-            return Enumerable.Empty<SeriesInformation>();
-        }
+            x.SeriesNameEn.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase)).ToList() ?? Enumerable.Empty<SeriesInformation>();
 
         // In case there are more than one result
         return relevantShows;

--- a/SdarotAPI/SdarotDriver.cs
+++ b/SdarotAPI/SdarotDriver.cs
@@ -2,7 +2,7 @@
 
 public class SdarotDriver
 {
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
 
     public SdarotDriver() : this(false) { }
 

--- a/SdarotAPI/SdarotDriver.cs
+++ b/SdarotAPI/SdarotDriver.cs
@@ -18,7 +18,7 @@ public class SdarotDriver
 
     public SdarotDriver(bool ignoreChecks)
     {
-        HttpClientHandler handler = new HttpClientHandler()
+        HttpClientHandler handler = new HttpClientHandler
         {
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
         };
@@ -78,10 +78,8 @@ public class SdarotDriver
             x.SeriesNameHe.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase) ||
             x.SeriesNameEn.Contains(searchQuery, StringComparison.CurrentCultureIgnoreCase)).ToList();
 
-        //var doc = new HtmlDocument();
-        //doc.LoadHtml(searchHtml);
-
-        //var seriesNameElement = doc.DocumentNode.SelectSingleNode(Constants.XPathSelectors.SeriesPageSeriesName);
+        // If none, turn to empty array.
+        relevantShows ??= new List<SeriesInformation>();
 
         // In case there is only one result
         if (relevantShows.Count() == 1)

--- a/SdarotAPITest/ApiUnitTest.cs
+++ b/SdarotAPITest/ApiUnitTest.cs
@@ -24,7 +24,7 @@ public class ApiUnitTest
 
         Assert.AreEqual(0, (await driver.SearchSeries("dsakdjaslkfjsalkjfas")).Count());
         Assert.AreEqual(15, (await driver.SearchSeries("שמש")).Count());
-        Assert.AreEqual(75, (await driver.SearchSeries("ana")).Count());
+        Assert.AreEqual(77, (await driver.SearchSeries("ana")).Count());
         Assert.AreEqual(1, (await driver.SearchSeries("shemesh")).Count());
     }
 


### PR DESCRIPTION
The current series search mechanism is broken. This fix is using the current method the web interface is working with: loading a JSON file beforehand, then searching it accordingly.
In the future, it would be better to preload it only once, when we start the console app, but for now it downloads the JSON file every time when performing a search.
Nevertheless: the search is currently working with the suggested fix.